### PR TITLE
Corrected function usage and improved subsequent query handling in RAG

### DIFF
--- a/ragpipe/colbert.py
+++ b/ragpipe/colbert.py
@@ -116,7 +116,7 @@ def test_colbert():
         'we should play tennis tomorrow',
         'elections are due soon'
     ]
-    scores = colbert.compute_similarity(query, docs)
+    scores = colbert.compute_similarity_text(query, docs)
     print(scores)
     
 

--- a/ragpipe/flow.py
+++ b/ragpipe/flow.py
@@ -45,7 +45,11 @@ class RepManager:
                 print(f'Unable to resolve repkey {repkey}. Did you define rep config for {repkey} correctly?')
                 raise e
         
-        return self.reps[repkey]
+        try:
+            return self.reps[repkey]
+        finally:
+            if repkey.startswith('query.text'):
+                del self.reps[repkey] 
 
 
 RMPool = {} #config_fname -> RepManager (move to RepManager.from_config ?)


### PR DESCRIPTION
- The first commit fixes the function used for computing similarity.
- The second commit ensures that each query has a unique embedding and that subsequent queries don’t rely on the first query's embedding.
